### PR TITLE
Corrigida opção para incluir tarifário indexado da EDP

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
     </div>
     <div style="display: flex; align-items: center; gap: 2px;">     
         <input type="checkbox" id="incluirEDP" style="margin: 0; padding: 0; width: 16px; height: 16px;">
-        <label for="restringir" style="margin: 4px;">Incluir desconto mensal de 10€ no EDP indexado</label>
+        <label for="incluirEDP" style="margin: 4px;">Incluir desconto mensal de 10€ no EDP indexado</label>
     </div>
 
 


### PR DESCRIPTION
Ao carregar na label "Incluir desconto mensal de 10€ no EDP indexado", a opção marcada era a anterior "Restringir aos tarifários do simulador Excel" devido a um erro na referência à checkbox.

Com esta correção é possível marcar a caixa ou carregar na label referente à nova opção da EDP para ativar a opção pretendida.